### PR TITLE
feat(n26): add new transaction type mappings

### DIFF
--- a/src/ofxstatement/plugins/n26.py
+++ b/src/ofxstatement/plugins/n26.py
@@ -28,6 +28,9 @@ TYPE_MAPPING = {
     "MasterCard Payment": "POS",
     "Outgoing Transfer": "XFER",
     "Direct Debit": "XFER",
+    "Credit Transfer": "XFER",
+    "Debit Transfer": "XFER",
+    "Presentment": "POS",
 
     # Add translations for other statements
 }


### PR DESCRIPTION

Add mappings for Credit Transfer, Debit Transfer and Presentment transaction
types to support additional N26 statement formats.
